### PR TITLE
Ignore trailing slashes on F::relativepath()

### DIFF
--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -672,7 +672,7 @@ class F
             return str_pad('', count($inParts) * strlen($parentToken), $parentToken) . implode('/', $fileParts);
         }
 
-        return Str::after($file, $in . '/');
+        return '/' . Str::after($file, $in . '/');
     }
 
     /**

--- a/src/Toolkit/F.php
+++ b/src/Toolkit/F.php
@@ -654,11 +654,15 @@ class F
         $file = str_replace('\\', '/', $file);
         $in   = str_replace('\\', '/', $in);
 
-        if (Str::contains($file, $in) === false) {
+        // trim trailing slashes
+        $file = rtrim($file, '/');
+        $in   = rtrim($in, '/');
+
+        if (Str::contains($file, $in . '/') === false) {
             // make the paths relative by stripping what they have
             // in common and adding `../` tokens at the start
-            $fileParts = explode('/', rtrim($file, '/'));
-            $inParts = explode('/', rtrim($in, '/'));
+            $fileParts = explode('/', $file);
+            $inParts = explode('/', $in);
             while (count($fileParts) && count($inParts) && ($fileParts[0] === $inParts[0])) {
                 array_shift($fileParts);
                 array_shift($inParts);
@@ -668,7 +672,7 @@ class F
             return str_pad('', count($inParts) * strlen($parentToken), $parentToken) . implode('/', $fileParts);
         }
 
-        return Str::after($file, $in);
+        return Str::after($file, $in . '/');
     }
 
     /**

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -500,7 +500,7 @@ class ApiTest extends TestCase
             'code'      => 500,
             'exception' => 'Exception',
             'key'       => null,
-            'file'      => '/' . basename(__FILE__),
+            'file'      => basename(__FILE__),
             'line'      => __LINE__ - 18,
             'details'   => [],
             'route'     => 'test'
@@ -578,7 +578,7 @@ class ApiTest extends TestCase
             'code'      => 404,
             'exception' => 'Kirby\\Exception\\NotFoundException',
             'key'       => 'error.test',
-            'file'      => '/' . basename(__FILE__),
+            'file'      => basename(__FILE__),
             'line'      => __LINE__ - 24,
             'details'   => ['a' => 'A'],
             'route'     => 'test',

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -500,7 +500,7 @@ class ApiTest extends TestCase
             'code'      => 500,
             'exception' => 'Exception',
             'key'       => null,
-            'file'      => basename(__FILE__),
+            'file'      => '/' . basename(__FILE__),
             'line'      => __LINE__ - 18,
             'details'   => [],
             'route'     => 'test'
@@ -578,7 +578,7 @@ class ApiTest extends TestCase
             'code'      => 404,
             'exception' => 'Kirby\\Exception\\NotFoundException',
             'key'       => 'error.test',
-            'file'      => basename(__FILE__),
+            'file'      => '/' . basename(__FILE__),
             'line'      => __LINE__ - 24,
             'details'   => ['a' => 'A'],
             'route'     => 'test',

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -160,10 +160,10 @@ class FTest extends TestCase
     public function testRelativePath()
     {
         $path = F::relativepath(__FILE__, __DIR__);
-        $this->assertEquals(basename(__FILE__), $path);
+        $this->assertEquals('/' . basename(__FILE__), $path);
         
         $path = F::relativepath(__FILE__, __DIR__ . '/');
-        $this->assertEquals(basename(__FILE__), $path);
+        $this->assertEquals('/' . basename(__FILE__), $path);
     }
 
     public function testRelativePathWithEmptyBase()
@@ -208,7 +208,7 @@ class FTest extends TestCase
         $in   = 'C:/xampp/htdocs';
 
         $path = F::relativepath($file, $in);
-        $this->assertEquals('index.php', $path);
+        $this->assertEquals('/index.php', $path);
     }
 
     public function testSymlink()

--- a/tests/Toolkit/FTest.php
+++ b/tests/Toolkit/FTest.php
@@ -160,7 +160,10 @@ class FTest extends TestCase
     public function testRelativePath()
     {
         $path = F::relativepath(__FILE__, __DIR__);
-        $this->assertEquals('/' . basename(__FILE__), $path);
+        $this->assertEquals(basename(__FILE__), $path);
+        
+        $path = F::relativepath(__FILE__, __DIR__ . '/');
+        $this->assertEquals(basename(__FILE__), $path);
     }
 
     public function testRelativePathWithEmptyBase()
@@ -194,6 +197,9 @@ class FTest extends TestCase
         
         $path = F::relativepath(__DIR__ . '/test.txt', __DIR__ . '/foo/bar/baz');
         $this->assertEquals('../../../test.txt', $path);
+        
+        $path = F::relativepath('foo/path-extra/file.txt', 'foo/path');
+        $this->assertEquals('../path-extra/file.txt', $path);
     }
 
     public function testRelativePathOnWindows()
@@ -202,7 +208,7 @@ class FTest extends TestCase
         $in   = 'C:/xampp/htdocs';
 
         $path = F::relativepath($file, $in);
-        $this->assertEquals('/index.php', $path);
+        $this->assertEquals('index.php', $path);
     }
 
     public function testSymlink()


### PR DESCRIPTION
## Describe the PR
Always trims slashes, as suggested by @lukasbestle https://github.com/getkirby/kirby/pull/3268#issuecomment-830833428

## Related issues
PR relates to issues in the `kirby` or `idea` repo:
- Extends https://github.com/getkirby/kirby/pull/3268
